### PR TITLE
aosp-cve-O8.0.0-1.0.0: Use MF0300 frameworks/opt/net/ethernet repo

### DIFF
--- a/aosp-cve-O8.0.0-1.0.0.xml
+++ b/aosp-cve-O8.0.0-1.0.0.xml
@@ -355,7 +355,7 @@
   <project path="frameworks/opt/datetimepicker" name="platform/frameworks/opt/datetimepicker" groups="pdk-cw-fs,pdk-fs" />
   <project path="frameworks/opt/inputconnectioncommon" name="platform/frameworks/opt/inputconnectioncommon" groups="pdk-fs" />
   <project path="frameworks/opt/inputmethodcommon" name="platform/frameworks/opt/inputmethodcommon" groups="pdk-cw-fs,pdk-fs" />
-  <project path="frameworks/opt/net/ethernet" name="platform/frameworks/opt/net/ethernet" groups="pdk-fs" />
+  <project path="frameworks/opt/net/ethernet" name="MF0300-AOSP/platform-frameworks-opt-net-ethernet" groups="pdk-fs" remote="github" revision="o8.0.0_1.0.0-ga"/>
   <project path="frameworks/opt/net/ims" name="platform/frameworks/opt/net/ims" groups="frameworks_ims,pdk-cw-fs,pdk-fs" />
   <project path="frameworks/opt/net/lowpan" name="platform/frameworks/opt/net/lowpan" groups="pdk-fs" />
   <project path="frameworks/opt/net/voip" name="platform/frameworks/opt/net/voip" groups="pdk-cw-fs,pdk-fs" />


### PR DESCRIPTION
Use MF0300 frameworks/opt/net/ethernet repo instead of google frameworks/opt/net/ethernet repo.