### PR TITLE
aosp-cve-O8.0.0-1.0.0: Move MF0300 CVE repos to imx6q-mf0300

### DIFF
--- a/aosp-cve-O8.0.0-1.0.0.xml
+++ b/aosp-cve-O8.0.0-1.0.0.xml
@@ -8,10 +8,6 @@
            remote="aosp"
            sync-j="4" />
 
-  <remote  name="github"
-           fetch="https://github.com/"
-           review="" />
-
   <project path="build/blueprint" name="platform/build/blueprint" groups="pdk,tradefed" />
   <project path="build/kati" name="platform/build/kati" groups="pdk,tradefed" />
   <project path="art" name="platform/art" groups="pdk" />
@@ -67,7 +63,6 @@
   <project path="device/linaro/hikey-kernel" name="device/linaro/hikey-kernel" groups="device,hikey,pdk" clone-depth="1" />
   <project path="device/sample" name="device/sample" groups="pdk" />
   <project path="docs/source.android.com" name="platform/docs/source.android.com" groups="pdk-cw-fs,pdk-fs" />
-  <project path="external/aac" name="MF0300-AOSP/platform-external-aac" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
   <project path="external/abi-compliance-checker" name="platform/external/abi-compliance-checker" groups="pdk" />
   <project path="external/abi-dumper" name="platform/external/abi-dumper" groups="pdk" />
   <project path="external/adt-infra" name="platform/external/adt-infra" groups="adt-infra,notdefault,pdk-fs" />
@@ -94,7 +89,6 @@
   <project path="external/c-ares" name="platform/external/c-ares" groups="pdk" />
   <project path="external/caliper" name="platform/external/caliper" groups="pdk" />
   <project path="external/cblas" name="platform/external/cblas" groups="pdk" />
-  <project path="external/chromium-libpac" name="MF0300-AOSP/platform-external-chromium-libpac" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
   <project path="external/chromium-trace" name="platform/external/chromium-trace" groups="pdk" />
   <project path="external/chromium-webview" name="platform/external/chromium-webview" groups="pdk" clone-depth="1" />
   <project path="external/clang" name="platform/external/clang" groups="pdk" />
@@ -118,7 +112,6 @@
   <project path="external/drm_hwcomposer" name="platform/external/drm_hwcomposer" groups="drm_hwcomposer,pdk-fs" />
   <project path="external/droiddriver" name="platform/external/droiddriver" groups="pdk" />
   <project path="external/dtc" name="platform/external/dtc" groups="pdk" />
-  <project path="external/e2fsprogs" name="MF0300-AOSP/platform-external-e2fsprogs" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
   <project path="external/easymock" name="platform/external/easymock" groups="pdk" />
   <project path="external/eclipse-basebuilder" name="platform/external/eclipse-basebuilder" groups="pdk-cw-fs,pdk-fs" />
   <project path="external/eclipse-windowbuilder" name="platform/external/eclipse-windowbuilder" groups="pdk" />
@@ -182,7 +175,6 @@
   <project path="external/kernel-headers" name="platform/external/kernel-headers" groups="pdk" />
   <project path="external/kmod" name="platform/external/kmod" groups="pdk" />
   <project path="external/ksoap2" name="platform/external/ksoap2" groups="pdk" />
-  <project path="external/libavc" name="MF0300-AOSP/platform-external-libavc" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
   <project path="external/libbackup" name="platform/external/libbackup" groups="pdk" />
   <project path="external/libbrillo" name="platform/external/libbrillo" groups="pdk" />
   <project path="external/libcap" name="platform/external/libcap" groups="pdk" />
@@ -200,13 +192,11 @@
   <project path="external/libevent" name="platform/external/libevent" groups="pdk" />
   <project path="external/libexif" name="platform/external/libexif" groups="pdk" />
   <project path="external/libgsm" name="platform/external/libgsm" groups="pdk" />
-  <project path="external/libhevc" name="MF0300-AOSP/platform-external-libhevc" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
   <project path="external/libjpeg-turbo" name="platform/external/libjpeg-turbo" groups="pdk" />
   <project path="external/libldac" name="platform/external/libldac" groups="pdk" />
   <project path="external/liblzf" name="platform/external/liblzf" groups="pdk" />
   <project path="external/libmicrohttpd" name="platform/external/libmicrohttpd" groups="pdk" />
   <project path="external/libmojo" name="platform/external/libmojo" groups="pdk" />
-  <project path="external/libmpeg2" name="MF0300-AOSP/platform-external-libmpeg2" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
   <project path="external/libmtp" name="platform/external/libmtp" groups="pdk" />
   <project path="external/libnetfilter_conntrack" name="platform/external/libnetfilter_conntrack" groups="pdk" />
   <project path="external/libnfnetlink" name="platform/external/libnfnetlink" groups="pdk" />
@@ -223,9 +213,7 @@
   <project path="external/libutf" name="platform/external/libutf" groups="pdk" />
   <project path="external/libvncserver" name="platform/external/libvncserver" groups="pdk" />
   <project path="external/libvorbis" name="platform/external/libvorbis" groups="pdk" />
-  <project path="external/libvpx" name="MF0300-AOSP/platform-external-libvpx" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
   <project path="external/libvterm" name="platform/external/libvterm" groups="pdk" />
-  <project path="external/libxml2" name="MF0300-AOSP/platform-external-libxml2" groups="pdk,libxml2" remote="github" revision="o8.0.0_1.0.0-ga" />
   <project path="external/libtextclassifier" name="platform/external/libtextclassifier" groups="pdk" />
   <project path="external/libyuv" name="platform/external/libyuv" groups="pdk,libyuv" />
   <project path="external/linux-kselftest" name="platform/external/linux-kselftest" groups="vts,pdk" />
@@ -256,7 +244,6 @@
   <project path="external/naver-fonts" name="platform/external/naver-fonts" groups="pdk" />
   <project path="external/netcat" name="platform/external/netcat" groups="pdk" />
   <project path="external/netperf" name="platform/external/netperf" groups="pdk" />
-  <project path="external/neven" name="MF0300-AOSP/platform-external-neven" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
   <project path="external/nfacct" name="platform/external/nfacct" groups="pdk" />
   <project path="external/nist-pkits" name="platform/external/nist-pkits" groups="pdk" />
   <project path="external/nist-sip" name="platform/external/nist-sip" groups="pdk" />
@@ -289,20 +276,17 @@
   <project path="external/selinux" name="platform/external/selinux" groups="pdk" />
   <project path="external/shflags" name="platform/external/shflags" groups="pdk" />
   <project path="external/sfntly" name="platform/external/sfntly" groups="pdk,qcom_msm8x26" />
-  <project path="external/skia" name="MF0300-AOSP/platform-external-skia" groups="pdk,qcom_msm8x26" remote="github" revision="o8.0.0_1.0.0-ga" />
   <project path="external/sl4a" name="platform/external/sl4a" groups="pdk" />
   <project path="external/slf4j" name="platform/external/slf4j" groups="pdk" />
   <project path="external/smali" name="platform/external/smali" groups="pdk" />
   <project path="external/snakeyaml" name="platform/external/snakeyaml" groups="pdk" />
   <project path="external/sonic" name="platform/external/sonic" groups="pdk" />
   <project path="external/spirv-llvm" name="platform/external/spirv-llvm" />
-  <project path="external/sonivox" name="MF0300-AOSP/platform-external-sonivox" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
   <project path="external/speex" name="platform/external/speex" groups="pdk" />
   <project path="external/sqlite" name="platform/external/sqlite" groups="pdk" />
   <project path="external/squashfs-tools" name="platform/external/squashfs-tools" groups="pdk" />
   <project path="external/strace" name="platform/external/strace" groups="pdk" />
   <project path="external/stressapptest" name="platform/external/stressapptest" groups="pdk" />
-  <project path="external/svox" name="MF0300-AOSP/platform-external-svox" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
   <project path="external/syslinux" name="platform/external/syslinux" groups="pdk" />
   <project path="external/swiftshader" name="platform/external/swiftshader" groups="pdk" />
   <project path="external/tagsoup" name="platform/external/tagsoup" groups="pdk" />
@@ -316,10 +300,8 @@
   <project path="external/toybox" name="platform/external/toybox" groups="pdk" />
   <project path="external/tpm2" name="platform/external/tpm2" groups="pdk" />
   <project path="external/trappy" name="platform/external/trappy" groups="pdk" />
-  <project path="external/tremolo" name="MF0300-AOSP/platform-external-tremolo" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
   <project path="external/unicode" name="platform/external/unicode" groups="pdk" />
   <project path="external/universal-tween-engine" name="platform/external/universal-tween-engine" />
-  <project path="external/v8" name="MF0300-AOSP/platform-external-v8" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
   <project path="external/v4l2_codec2" name="platform/external/v4l2_codec2" groups="pdk" />
   <project path="external/valgrind" name="platform/external/valgrind" groups="pdk" />
   <project path="external/vboot_reference" name="platform/external/vboot_reference" groups="vboot,pdk-fs" />
@@ -330,7 +312,6 @@
   <project path="external/walt" name="platform/external/walt" groups="pdk" />
   <project path="external/webp" name="platform/external/webp" groups="pdk,qcom_msm8x26" />
   <project path="external/webrtc" name="platform/external/webrtc" groups="pdk" />
-  <project path="external/wpa_supplicant_8" name="MF0300-AOSP/platform-external-wpa_supplicant_8" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
   <project path="external/wycheproof" name="platform/external/wycheproof" groups="pdk" />
   <project path="external/x264" name="platform/external/x264" groups="pdk" />
   <project path="external/xmlrpcpp" name="platform/external/xmlrpcpp" groups="pdk" />
@@ -342,9 +323,7 @@
   <project path="frameworks/compile/libbcc" name="platform/frameworks/compile/libbcc" groups="pdk" />
   <project path="frameworks/compile/mclinker" name="platform/frameworks/compile/mclinker" groups="pdk" />
   <project path="frameworks/compile/slang" name="platform/frameworks/compile/slang" groups="pdk" />
-  <project path="frameworks/ex" name="MF0300-AOSP/platform-frameworks-ex" groups="pdk-cw-fs,pdk-fs" remote="github" revision="o8.0.0_1.0.0-ga" />
   <project path="frameworks/hardware/interfaces" name="platform/frameworks/hardware/interfaces" groups="pdk" />
-  <project path="frameworks/minikin" name="MF0300-AOSP/platform-frameworks-minikin" groups="pdk-cw-fs,pdk-fs" remote="github" revision="o8.0.0_1.0.0-ga" />
   <project path="frameworks/ml" name="platform/frameworks/ml" groups="pdk-cw-fs,pdk-fs" />
   <project path="frameworks/multidex" name="platform/frameworks/multidex" groups="pdk-cw-fs,pdk-fs" />
   <project path="frameworks/opt/bitmap" name="platform/frameworks/opt/bitmap" groups="pdk-fs" />
@@ -362,7 +341,6 @@
   <project path="frameworks/opt/net/wifi" name="platform/frameworks/opt/net/wifi" groups="pdk" />
   <project path="frameworks/opt/photoviewer" name="platform/frameworks/opt/photoviewer" groups="pdk-cw-fs,pdk-fs" />
   <project path="frameworks/opt/setupwizard" name="platform/frameworks/opt/setupwizard" groups="pdk-cw-fs,pdk-fs" />
-  <project path="frameworks/opt/telephony" name="MF0300-AOSP/platform-frameworks-opt-telephony" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
   <project path="frameworks/opt/timezonepicker" name="platform/frameworks/opt/timezonepicker" groups="pdk-cw-fs,pdk-fs" />
   <project path="frameworks/opt/vcard" name="platform/frameworks/opt/vcard" groups="pdk-cw-fs,pdk-fs" />
   <project path="frameworks/rs" name="platform/frameworks/rs" groups="pdk" />
@@ -414,7 +392,6 @@
   <project path="hardware/qcom/wlan" name="platform/hardware/qcom/wlan" groups="qcom_wlan,pdk" />
   <project path="hardware/ril" name="platform/hardware/ril" groups="pdk" />
   <project path="kernel/tests" name="kernel/tests" />
-  <project path="libcore" name="MF0300-AOSP/platform-libcore" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
   <project path="libnativehelper" name="platform/libnativehelper" groups="pdk" />
   <project path="packages/apps/BasicSmsReceiver" name="platform/packages/apps/BasicSmsReceiver" groups="pdk-cw-fs,pdk-fs" />
   <project path="packages/apps/Browser2" name="platform/packages/apps/Browser2" groups="pdk-fs" />
@@ -439,14 +416,12 @@
   <project path="packages/apps/MusicFX" name="platform/packages/apps/MusicFX" groups="pdk-fs" />
   <project path="packages/apps/Nfc" name="platform/packages/apps/Nfc" groups="apps_nfc,pdk-fs" />
   <project path="packages/apps/OneTimeInitializer" name="platform/packages/apps/OneTimeInitializer" groups="pdk-fs" />
-  <project path="packages/apps/PackageInstaller" name="MF0300-AOSP/platform-packages-apps-PackageInstaller" groups="pdk-cw-fs,pdk-fs" remote="github" revision="imx6q-mf0300_o8.0.0_1.0.0-ga" />
   <project path="packages/apps/PhoneCommon" name="platform/packages/apps/PhoneCommon" groups="pdk-cw-fs,pdk-fs" />
   <project path="packages/apps/Protips" name="platform/packages/apps/Protips" groups="pdk-fs" />
   <project path="packages/apps/Provision" name="platform/packages/apps/Provision" groups="pdk-fs" />
   <project path="packages/apps/QuickSearchBox" name="platform/packages/apps/QuickSearchBox" groups="pdk-fs" />
   <project path="packages/apps/RetailDemo" name="platform/packages/apps/RetailDemo" groups="pdk-fs" />
   <project path="packages/apps/SafetyRegulatoryInfo" name="platform/packages/apps/SafetyRegulatoryInfo" groups="pdk-fs" />
-  <project path="packages/apps/Settings" name="MF0300-AOSP/platform-packages-apps-Settings" groups="pdk-fs" remote="github" revision="imx6q-mf0300_o8.0.0_1.0.0-ga" />
   <project path="packages/apps/SpareParts" name="platform/packages/apps/SpareParts" groups="pdk-fs" />
   <project path="packages/apps/Stk" name="platform/packages/apps/Stk" groups="apps_stk,pdk-fs" />
   <project path="packages/apps/StorageManager" name="platform/packages/apps/StorageManager" groups="pdk-fs" />
@@ -465,7 +440,6 @@
   <project path="packages/providers/CalendarProvider" name="platform/packages/providers/CalendarProvider" groups="pdk-cw-fs,pdk-fs" />
   <project path="packages/providers/CallLogProvider" name="platform/packages/providers/CallLogProvider" groups="pdk-fs" />
   <project path="packages/providers/ContactsProvider" name="platform/packages/providers/ContactsProvider" groups="pdk-cw-fs,pdk-fs" />
-  <project path="packages/providers/DownloadProvider" name="MF0300-AOSP/platform-packages-providers-DownloadProvider" groups="pdk-cw-fs,pdk-fs" remote="github" revision="o8.0.0_1.0.0-ga" />
   <project path="packages/providers/MediaProvider" name="platform/packages/providers/MediaProvider" groups="pdk-cw-fs,pdk-fs" />
   <project path="packages/providers/PartnerBookmarksProvider" name="platform/packages/providers/PartnerBookmarksProvider" groups="pdk-fs" />
   <project path="packages/providers/TelephonyProvider" name="platform/packages/providers/TelephonyProvider" groups="pdk-cw-fs,pdk-fs" />
@@ -539,7 +513,6 @@
   <project path="prebuilts/sdk" name="platform/prebuilts/sdk" groups="pdk" clone-depth="1" />
   <project path="prebuilts/tools" name="platform/prebuilts/tools" groups="pdk,tools" clone-depth="1" />
   <project path="sdk" name="platform/sdk" groups="pdk-cw-fs,pdk-fs" />
-  <project path="system/bt" name="MF0300-AOSP/platform-system-bt" groups="pdk" remote="github" revision="imx6q-mf0300_o8.0.0_1.0.0-ga" />
   <project path="system/ca-certificates" name="platform/system/ca-certificates" groups="pdk" />
   <project path="system/connectivity/wificond" name="platform/system/connectivity/wificond" groups="pdk" />
   <project path="system/connectivity/wifilogd" name="platform/system/connectivity/wifilogd" groups="pdk" />
@@ -549,21 +522,15 @@
   <project path="system/hwservicemanager" name="platform/system/hwservicemanager" groups="pdk" />
   <project path="system/keymaster" name="platform/system/keymaster" groups="pdk" />
   <project path="system/libfmq" name="platform/system/libfmq" groups="pdk" />
-  <project path="system/libhidl" name="MF0300-AOSP/platform-system-libhidl" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
   <project path="system/libhwbinder" name="platform/system/libhwbinder" groups="pdk" />
   <project path="system/libufdt" name="platform/system/libufdt" groups="pdk" />
   <project path="system/libvintf" name="platform/system/libvintf" groups="pdk" />
-  <project path="system/media" name="MF0300-AOSP/platform-system-media" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
   <project path="system/netd" name="platform/system/netd" groups="pdk" />
-  <project path="system/nfc" name="MF0300-AOSP/platform-system-nfc" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
   <project path="system/nvram" name="platform/system/nvram" groups="pdk" />
-  <project path="system/security" name="MF0300-AOSP/platform-system-security" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
-  <project path="system/sepolicy" name="MF0300-AOSP/platform-system-sepolicy" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
   <project path="system/tools/aidl" name="platform/system/tools/aidl" groups="pdk" />
   <project path="system/tools/hidl" name="platform/system/tools/hidl" groups="pdk" />
   <project path="system/tpm" name="platform/system/tpm" />
   <project path="system/update_engine" name="platform/system/update_engine" groups="pdk" />
-  <project path="system/vold" name="MF0300-AOSP/platform-system-vold" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
   <project path="test/vts" name="platform/test/vts" groups="vts,pdk" />
   <project path="test/vts-testcase/fuzz" name="platform/test/vts-testcase/fuzz" groups="vts,pdk" />
   <project path="test/vts-testcase/hal" name="platform/test/vts-testcase/hal" groups="vts,pdk" />

--- a/imx6q-mf0300-o8.0.0_1.0.0_ga.xml
+++ b/imx6q-mf0300-o8.0.0_1.0.0_ga.xml
@@ -15,6 +15,10 @@
            fetch="https://github.com/MF0300-AOSP/"
            review="" />
 
+  <remote  name="github"
+           fetch="https://github.com/"
+           review="" />
+
   <!--> imx-firmware needs to be fetched from git.freescale.com as it is proprietary <-->
   <project path="vendor/nxp/imx-firmware" name="imx-firmware" remote="mf0300" revision="imx_o8.0.0_1.0.0-ga" />
 
@@ -61,5 +65,36 @@
   <project path="system/core" name="platform-system-core" groups="pdk" remote="mf0300" revision="imx6q-mf0300_o8.0.0_1.0.0-ga" />
   <project path="system/extras" name="aosp/platform/system/extras" groups="pdk" remote="android-imx" revision="refs/tags/o8.0.0_1.0.0-ga" />
   <project path="system/tools/bpt" name="aosp/platform/system/tools/bpt" groups="pdk" remote="android-imx" revision="refs/tags/o8.0.0_1.0.0-ga"/>
+
+
+  <project path="external/libxml2" name="MF0300-AOSP/platform-external-libxml2" groups="pdk,libxml2" remote="github" revision="o8.0.0_1.0.0-ga" />
+  <project path="external/libvpx" name="MF0300-AOSP/platform-external-libvpx" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
+  <project path="external/libmpeg2" name="MF0300-AOSP/platform-external-libmpeg2" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
+  <project path="external/libhevc" name="MF0300-AOSP/platform-external-libhevc" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
+  <project path="external/libavc" name="MF0300-AOSP/platform-external-libavc" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
+  <project path="external/e2fsprogs" name="MF0300-AOSP/platform-external-e2fsprogs" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
+  <project path="external/chromium-libpac" name="MF0300-AOSP/platform-external-chromium-libpac" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
+  <project path="external/aac" name="MF0300-AOSP/platform-external-aac" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
+  <project path="external/neven" name="MF0300-AOSP/platform-external-neven" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
+  <project path="external/skia" name="MF0300-AOSP/platform-external-skia" groups="pdk,qcom_msm8x26" remote="github" revision="o8.0.0_1.0.0-ga" />
+  <project path="external/sonivox" name="MF0300-AOSP/platform-external-sonivox" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
+  <project path="external/svox" name="MF0300-AOSP/platform-external-svox" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
+  <project path="external/tremolo" name="MF0300-AOSP/platform-external-tremolo" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
+  <project path="external/v8" name="MF0300-AOSP/platform-external-v8" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
+  <project path="external/wpa_supplicant_8" name="MF0300-AOSP/platform-external-wpa_supplicant_8" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
+  <project path="frameworks/ex" name="MF0300-AOSP/platform-frameworks-ex" groups="pdk-cw-fs,pdk-fs" remote="github" revision="o8.0.0_1.0.0-ga" />
+  <project path="frameworks/minikin" name="MF0300-AOSP/platform-frameworks-minikin" groups="pdk-cw-fs,pdk-fs" remote="github" revision="o8.0.0_1.0.0-ga" />
+  <project path="frameworks/opt/telephony" name="MF0300-AOSP/platform-frameworks-opt-telephony" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
+  <project path="libcore" name="MF0300-AOSP/platform-libcore" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
+  <project path="packages/apps/PackageInstaller" name="MF0300-AOSP/platform-packages-apps-PackageInstaller" groups="pdk-cw-fs,pdk-fs" remote="github" revision="imx6q-mf0300_o8.0.0_1.0.0-ga" />
+  <project path="packages/apps/Settings" name="MF0300-AOSP/platform-packages-apps-Settings" groups="pdk-fs" remote="github" revision="imx6q-mf0300_o8.0.0_1.0.0-ga" />
+  <project path="packages/providers/DownloadProvider" name="MF0300-AOSP/platform-packages-providers-DownloadProvider" groups="pdk-cw-fs,pdk-fs" remote="github" revision="o8.0.0_1.0.0-ga" />
+  <project path="system/bt" name="MF0300-AOSP/platform-system-bt" groups="pdk" remote="github" revision="imx6q-mf0300_o8.0.0_1.0.0-ga" />
+  <project path="system/libhidl" name="MF0300-AOSP/platform-system-libhidl" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
+  <project path="system/media" name="MF0300-AOSP/platform-system-media" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
+  <project path="system/nfc" name="MF0300-AOSP/platform-system-nfc" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
+  <project path="system/security" name="MF0300-AOSP/platform-system-security" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
+  <project path="system/sepolicy" name="MF0300-AOSP/platform-system-sepolicy" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
+  <project path="system/vold" name="MF0300-AOSP/platform-system-vold" groups="pdk" remote="github" revision="o8.0.0_1.0.0-ga" />
 
 </manifest>


### PR DESCRIPTION
For have an ability to switch between remotes.